### PR TITLE
custom_install: Some clients need to have subdir installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ The `defaults` vars declared in this module:
 ```YAML
 symfony_env: prod
 symfony_php_path: php # The PHP executable to use for all command line tasks
+# symfony_deployment_subdir: If clients have a special path in their release folder.
+#
+# e.g. if symfony_deployment_subdir is 'toto' then you'll be looking for:
+# releases/$VERSION/toto/composer.json etc instead of:
+# releases/$VERSION/composer.json
+symfony_deployment_subdir: ""
 
 symfony_run_composer: true
 symfony_composer_path: "{{ deployment_deploy_to }}/composer.phar"

--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -19,7 +19,7 @@
   become_user: "{{ deploy_user }}"
 
 - name: Run composer install | DEV
-  shell: chdir={{deployment_release_path.stdout}}
+  shell: chdir={{deployment_release_path.stdout}}/{{symfony_deployment_subdir}}
     export SYMFONY_ENV=dev && {{symfony_php_path}} {{symfony_composer_path}} install {{symfony_composer_options}}
   register: composer_install_result
   changed_when: composer_install_result.stderr | search('- \w+ing ')
@@ -28,7 +28,7 @@
   when: "'dev' in symfony_env"
 
 - name: Run composer install | PROD
-  shell: chdir={{deployment_release_path.stdout}}
+  shell: chdir={{deployment_release_path.stdout}}/{{symfony_deployment_subdir}}
     export SYMFONY_ENV=prod && {{symfony_php_path}} {{symfony_composer_path}} install {{symfony_composer_options}}
   register: composer_install_result
   changed_when: composer_install_result.stderr | search('- \w+ing ')

--- a/config/steps/schema.yml
+++ b/config/steps/schema.yml
@@ -1,6 +1,6 @@
 ---
 - name: Doctrine Schema Update
-  shell: chdir={{deployment_release_path.stdout}}
+  shell: chdir={{deployment_release_path.stdout}}/{{symfony_deployment_subdir}}
     {{symfony_php_path}} app/console doctrine:schema:update --env=prod {{ symfony_schema_options }}
   become: yes
   become_user: "{{ deploy_user }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ symfony_php_path: php # The PHP executable to use for all command line tasks
 
 symfony_run_composer: true
 symfony_composer_path: "{{ deployment_deploy_to }}/composer.phar"
+symfony_deployment_subdir: ""
 symfony_composer_options: '--no-dev --optimize-autoloader --no-interaction'
 symfony_composer_self_update: true # Always attempt a composer self-update
 


### PR DESCRIPTION
Some clients wants to install their app in a subdir of the release. So
it doesn't end up in release/app/composer.json but in something like:
release/custom_subdir/app/composer.json.
