### PR TITLE
composer: allow version specification

### DIFF
--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -13,10 +13,17 @@
   become: yes
   become_user: "{{ deploy_user }}"
 
-- name: Install composer
+- name: Install latest composer
   get_url: url=https://getcomposer.org/composer.phar dest={{symfony_composer_path}} mode=0755 validate_certs=no force=no
   become: yes
   become_user: "{{ deploy_user }}"
+  when: symfony_composer_version is not defined or symfony_composer_version | trim == ""
+
+- name: Install specific version of composer
+  get_url: url=https://getcomposer.org/download/{{symfony_composer_version}}/composer.phar dest={{symfony_composer_path}} mode=0755 validate_certs=no force=no
+  become: yes
+  become_user: "{{ deploy_user }}"
+  when: symfony_composer_version is defined and symfony_composer_version | trim != ""
 
 - name: Run composer install | DEV
   shell: chdir={{ansistrano_release_path.stdout}}/{{symfony_deployment_subdir}}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ symfony_env:
   - prod
 symfony_php_path: php # The PHP executable to use for all command line tasks
 
+symfony_composer_version: ""
 symfony_run_composer: true
 symfony_composer_path: "{{ ansistrano_deploy_to }}/composer.phar"
 symfony_deployment_subdir: ""


### PR DESCRIPTION
Default composer version can sometimes be buggy, it is therefore useful
to be able to specify a version desired and/or known as working.